### PR TITLE
Fixed a bug preventing libhoudini install

### DIFF
--- a/waydroid_extras.py
+++ b/waydroid_extras.py
@@ -368,7 +368,7 @@ on property:ro.enable.native.bridge.exec=1
     # Add entry to init.rc
     print("==> Adding entry to init.rc")
     print("==> Set android version: {}".format(os.environ.get("ANDROID_VERSION", "11")))
-    init_path = os.path.join(sys_image_mount, "system", "etc", "init", "hw", "init.rc") if os.environ.get("ANDROID_VERSION", "11") == "11" else os.path.join(sys_image_mount, "init.rc")
+    init_path = os.path.join(sys_image_mount, "system", "etc", "init", "hw", "init.rc") if os.environ.get("ANDROID_VERSION", "10") == "11" else os.path.join(sys_image_mount, "init.rc")
     with open(init_path, "r") as initfile:
         initcontent = initfile.read()
         if init_rc_component not in initcontent:


### PR DESCRIPTION
Libhoudini installation is still broken after last commit:
_FileNotFoundError: [Errno 2] No such file or directory: '/tmp/waydroidimage/system/etc/init/hw/init.rc'_

Setting the default value for os.environ.get("ANDROID_VERSION") back to 10 (it's the same for install_ndk method, wich is working fine)