### PR TITLE
container: Make missing dbus module non-fatal

### DIFF
--- a/tools/container.py
+++ b/tools/container.py
@@ -1,4 +1,7 @@
-import dbus
+try:
+    import dbus
+except ModuleNotFoundError:
+    pass
 
 def DBusContainerService(object_path="/ContainerManager", intf="id.waydro.ContainerManager"):
     return dbus.Interface(dbus.SystemBus().get_object("id.waydro.Container", object_path), intf)


### PR DESCRIPTION
This is required to properly support Waydroid tool versions <=1.3.4 (which NixOS for example still has), or 1.4.0+ configured with `USE_DBUS_ACTIVATION=0` (basically non-systemd distributions which can't supervise the container properly when it's launched via D-Bus)