### PR TITLE
Do not implicitly assume the presence of sudo

### DIFF
--- a/tools/helper.py
+++ b/tools/helper.py
@@ -54,7 +54,7 @@ def run(args: list, env: Optional[str] = None, ignore: Optional[str] = None):
 # execute on waydroid shell
 def shell(arg: str, env: Optional[str] = None):
     a = subprocess.Popen(
-        args=["sudo", "waydroid", "shell"],
+        args=["waydroid", "shell"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE

--- a/tools/images.py
+++ b/tools/images.py
@@ -24,8 +24,8 @@ def umount(mount_point, exists=True):
             mount_point))
 
 def resize(img_file, size):
-    run(["sudo", "e2fsck", "-y", "-f", img_file], ignore="^e2fsck \d+\.\d+\.\d (.+)\n$")
-    run(["sudo", "resize2fs", img_file, size], ignore="^resize2fs \d+\.\d+\.\d (.+)\n$")
+    run(["e2fsck", "-y", "-f", img_file], ignore="^e2fsck \d+\.\d+\.\d (.+)\n$")
+    run(["resize2fs", img_file, size], ignore="^resize2fs \d+\.\d+\.\d (.+)\n$")
 
 def get_image_dir():
     # Read waydroid config to get image location


### PR DESCRIPTION
This PR removes the unnecessary invocations of `sudo` when opening subprocesses. The presence of sudo should not be implicitly assumed.

For example, I'm running `doas` instead of `sudo`. So instead of `sudo python3 main.py`, I'd run `doas python3 main.py`. Once the program has superuser privileges, it should not ask for it again anyways.