### PR TITLE
[URGENT] Update nodataperm.py by changing MD5SUM hash to updated state

### DIFF
--- a/stuff/nodataperm.py
+++ b/stuff/nodataperm.py
@@ -10,7 +10,7 @@ class Nodataperm(General):
     id = "nodataperm"
     dl_links = {
         "11": ["https://github.com/ayasa520/hack_full_data_permission/archive/refs/heads/main.zip",
-               "eafd7b0986f3edaebaf1dd89f19d49bf"],
+               "8f067ef796c3f6849f9767a85496156f"],
         "13": ["", ""]
     }
     dl_file_name = "nodataperm.zip"


### PR DESCRIPTION
Change the MD5Sum Because trying it spams error because its invalid due to the publisher releasing update

Suggestion: Just add the main.zip to the Releases tag and let The script grab the 'stable' version there and just change it alongside with the python script library for update to not add issues again (if necessary)