### PR TITLE
Add Nix flake and improve derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,22 +1,4 @@
-with (import <nixpkgs> {});
-
-stdenv.mkDerivation {
-  name = "waydroid_script";
-
-  buildInputs = [
-    (python3.withPackages(ps: with ps; [ tqdm requests inquirerpy ]))
-  ];
-
-  src = ./.;
-
-  postPatch = ''
-    patchShebangs main.py
-  '';
-
-  installPhase = ''
-    mkdir -p $out/libexec
-    cp -r . $out/libexec/waydroid_script
-    mkdir -p $out/bin
-    ln -s $out/libexec/waydroid_script/main.py $out/bin/waydroid_script
-  '';
-}
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.callPackage ./package.nix { }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707650010,
+        "narHash": "sha256-dOhphIA4MGrH4ElNCy/OlwmN24MsnEqFjRR6+RY7jZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "809cca784b9f72a5ad4b991e0e7bcf8890f9c3a6",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Waydroid Extras Script";
+  inputs = {
+    systems.url = "github:nix-systems/default";
+  };
+  outputs = { self, nixpkgs, systems }:
+  let
+    inherit (nixpkgs) lib;
+    eachSystem = lib.genAttrs (import systems);
+    mkApp = program: { type = "app"; inherit program; };
+  in {
+    packages = eachSystem (system: rec {
+      waydroid_script = nixpkgs.legacyPackages."${system}".callPackage ./package.nix { };
+      default = waydroid_script;
+    });
+    apps = eachSystem (system: rec {
+      waydroid_script = mkApp "${self.outputs.packages.${system}.waydroid_script}/bin/waydroid_script";
+      default = waydroid_script;
+    });
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,32 @@
+{ lib,
+  stdenvNoCC,
+  lzip,
+  python3,
+  makeWrapper }:
+let
+  wrappedPath = lib.makeBinPath [ lzip ];
+in stdenvNoCC.mkDerivation {
+  name = "waydroid_script";
+
+  buildInputs = [
+    (python3.withPackages(ps: with ps; [ tqdm requests inquirerpy ]))
+  ];
+
+  nativeBuildInputs = [
+    makeWrapper
+  ];
+
+  src = ./.;
+
+  postPatch = ''
+    patchShebangs main.py
+  '';
+
+  installPhase = ''
+    mkdir -p $out/libexec
+    cp -r . $out/libexec/waydroid_script
+    mkdir -p $out/bin
+    makeShellWrapper $out/libexec/waydroid_script/main.py $out/bin/waydroid_script \
+      --prefix PATH : "${wrappedPath}"
+  '';
+}


### PR DESCRIPTION
This PR adds a Nix flake to the repo, which increases reproducibility and allows it to be run with `nix run github:casualsnek/waydroid_script`. It also updates the existing derivation so that it includes the `lzip` dependency in the script's `PATH`.