### PR TITLE
Fixed spelling/errors in reinit error messages

### DIFF
--- a/tools/container.py
+++ b/tools/container.py
@@ -22,7 +22,7 @@ def use_overlayfs():
     cfg = configparser.ConfigParser()
     cfg_file = os.environ.get("WAYDROID_CONFIG", "/var/lib/waydroid/waydroid.cfg")
     if not os.path.isfile(cfg_file):
-        Logger.error("Cannot locate waydroid config file, reinit wayland and try again!")
+        Logger.error("Cannot locate waydroid config file, reinit waydroid and try again!")
         sys.exit(1)
     cfg.read(cfg_file)
     if "waydroid" not in cfg:

--- a/tools/images.py
+++ b/tools/images.py
@@ -32,7 +32,7 @@ def get_image_dir():
     cfg = configparser.ConfigParser()
     cfg_file = os.environ.get("WAYDROID_CONFIG", "/var/lib/waydroid/waydroid.cfg")
     if not os.path.isfile(cfg_file):
-        Logger.error("Cannot locate waydroid config file, reinit wayland and try again!")
+        Logger.error("Cannot locate waydroid config file, reinit waydroid and try again!")
         sys.exit(1)
     cfg.read(cfg_file)
     if "waydroid" not in cfg:


### PR DESCRIPTION
Very simple changes to the debug/error messages in /tools. Just noticed it after nuking my waydroid install and though I would fix it up for you.