### PR TITLE
fix: Smartdock url update and md5 sum

### DIFF
--- a/stuff/smartdock.py
+++ b/stuff/smartdock.py
@@ -4,10 +4,10 @@ from stuff.general import General
 
 class Smartdock(General):
     id = "smartdock"
-    dl_link = "https://f-droid.org/repo/cu.axel.smartdock_1100.apk"
+    dl_link = "https://f-droid.org/repo/cu.axel.smartdock_1121.apk"
     partition = "system"
     dl_file_name = "smartdock.apk"
-    act_md5 = "f4087d34218eac902a5cca98ee03d215"
+    act_md5 = "dde94e2babc5f78bf7279e60a98eef05"
     apply_props = { "qemu.hw.mainkeys" : "1" }
     skip_extract = True
     permissions = """<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
The link to smartdock has changed. I updated it. Before installing smartdock, remember this. I tested to install smartdock with this project and the last version of smartdock, then the waydroid container was stuck on splash screen. I installed successfully the smartdock : install fdroid in waydroid and install smartdock with.