### PR TITLE
perf: `--depth=1` shallow clone for end users

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Script to add GApps and other stuff to Waydroid!
 
 ## Interactive terminal interface
 
-```
-git clone https://github.com/casualsnek/waydroid_script
+```bash
+git clone --depth=1 https://github.com/casualsnek/waydroid_script
 cd waydroid_script
 python3 -m venv venv
 venv/bin/pip install -r requirements.txt
@@ -25,7 +25,7 @@ sudo venv/bin/python3 main.py
 ## Command Line
 
 ```bash
-git clone https://github.com/casualsnek/waydroid_script
+git clone --depth=1 https://github.com/casualsnek/waydroid_script
 cd waydroid_script
 python3 -m venv venv
 venv/bin/pip install -r requirements.txt


### PR DESCRIPTION
## Summary

Speed up downloads of the script with a more efficient shallow clone

## Details

- rather than cloning the entire history of the repo, can do a shallow clone with a [depth](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--depthcodeemltdepthgtem) of 1
  - this should make it more efficient, particularly when there are many commits or many large commits
  - since the history is unused by regular end users, there is no need to fetch/download it

- also add syntax highlighting to the first code block, matching the second one

## Notes to Reviewers

- could alternatively do a [bare](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--barecode) clone to be even more efficient
  - but I thought a shallow clone is a bit less intrusive for now
    - and is reversible, if needed (i.e. a local shallow clone can fetch the rest of the depth)

## References

This is largely equivalent to https://github.com/ryanrudolfoba/SteamOS-Waydroid-Installer/pull/198