### PR TITLE
Fix microg installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ chmod 777 -R /mnt/*/*/*/*/Android/obb
 ![](assets/7.png)
 
 ```
-sudo python main.py install microg
+sudo venv/bin/python3 main.py install microg
 ```
 
 ## Hide Status Bar


### PR DESCRIPTION
The previous command returns an error ("ModuleNotFoundError: No module named 'InquirerPy'") even after installing the InquirerPy module using pip.