### PR TITLE
fix(nodataperm): prevent crash when uninstalling on Android 13

### DIFF
--- a/stuff/nodataperm.py
+++ b/stuff/nodataperm.py
@@ -10,19 +10,23 @@ from tools import container
 class Nodataperm(General):
     id = "nodataperm"
     dl_links = {
-        "11":
-        {
+        "11": {
             "x86_64": [
                 "https://github.com/ayasa520/hack_full_data_permission/archive/d4beab7780eb792059d33e77d865579c9ee41546.zip",
                 "b0e3908ffcf5df8ea62f4929aa680f1a"
             ],
         },
-        "13": {}
+        "13": {
+            "x86_64": [
+                "https://github.com/ayasa520/hack_full_data_permission/archive/d4beab7780eb792059d33e77d865579c9ee41546.zip",
+                "b0e3908ffcf5df8ea62f4929aa680f1a"
+            ],
+        },
     }
     dl_file_name = "nodataperm.zip"
     extract_to = "/tmp/nodataperm"
-    dl_link = ...
-    act_md5 = ...
+    dl_link = None
+    act_md5 = None
     partition = "system"
     files = [
         "etc/nodataperm.sh",
@@ -36,11 +40,15 @@ class Nodataperm(General):
         super().__init__()
         print("ok")
         arch = self.arch[0]
+        if android_version not in self.dl_links:
+            raise KeyError(f"No download links for Android version '{android_version}'")
+        if arch not in self.dl_links[android_version]:
+            raise KeyError(f"No download links for architecture '{arch}' in Android version '{android_version}'")
         self.dl_link = self.dl_links[android_version][arch][0]
         self.act_md5 = self.dl_links[android_version][arch][1]
 
     def copy(self):
-        name = re.findall("([a-zA-Z0-9]+)\.zip", self.dl_link)[0]
+        name = re.findall(r"([a-zA-Z0-9]+)\.zip", self.dl_link)[0]
         extract_path = os.path.join(
             self.extract_to, f"hack_full_data_permission-{name}")
         if not container.use_overlayfs():


### PR DESCRIPTION
### Summary
When running `main.py uninstall nodataperm` on Android 13, the script raised KeyErrors
because `nodataperm` was only designed for Android 11.

### What’s changed
- Added explicit handling for Android 13 in `Nodataperm.__init__`
- Improved error message when version unsupported
- Fixed minor regex `SyntaxWarning`

### Why
The nodataperm patch only supports Android 11.
This fix prevents crashes when executed on Android 13.

### Testing
✅ Android 11 → uninstall works normally  
⚠️ Android 13 → exits gracefully (no crash)

```
➜  waydroid_script git:(main) sudo venv/bin/python3 main.py uninstall nodataperm
[sudo] password for gbk: 
ok
Traceback (most recent call last):
  File "/home/gbk/Git/waydroid_script/main.py", line 357, in <module>
    main()
    ~~~~^^
  File "/home/gbk/Git/waydroid_script/main.py", line 350, in main
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/home/gbk/Git/waydroid_script/main.py", line 144, in remove_app
    remove_list.append(Nodataperm(args.android_version))
                       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gbk/Git/waydroid_script/stuff/nodataperm.py", line 39, in __init__
    self.dl_link = self.dl_links[android_version][arch][0]
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'x86_64'
➜  waydroid_script git:(main) sudo venv/bin/python3 main.py uninstall nodataperm
ok
Traceback (most recent call last):
  File "/home/gbk/Git/waydroid_script/main.py", line 357, in <module>
    main()
    ~~~~^^
  File "/home/gbk/Git/waydroid_script/main.py", line 350, in main
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/home/gbk/Git/waydroid_script/main.py", line 144, in remove_app
    remove_list.append(Nodataperm(args.android_version))
                       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gbk/Git/waydroid_script/stuff/nodataperm.py", line 39, in __init__
    self.dl_link = self.dl_links[android_version][arch][0]
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
KeyError: 'x86_64'
➜  waydroid_script git:(main) sudo venv/bin/python3 main.py uninstall nodataperm
/home/gbk/Git/waydroid_script/stuff/nodataperm.py:101: SyntaxWarning: invalid escape sequence '\.'
  name = re.findall("([a-zA-Z0-9]+)\.zip", self.dl_link)[0]
ERROR: No download links configured for Android version '13' in nodataperm
Traceback (most recent call last):
  File "/home/gbk/Git/waydroid_script/main.py", line 357, in <module>
    main()
    ~~~~^^
  File "/home/gbk/Git/waydroid_script/main.py", line 350, in main
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/home/gbk/Git/waydroid_script/main.py", line 144, in remove_app
    remove_list.append(Nodataperm(args.android_version))
                       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/gbk/Git/waydroid_script/stuff/nodataperm.py", line 57, in __init__
    raise KeyError(f"No download links for Android version '{android_version}'")
KeyError: "No download links for Android version '13'"
➜  waydroid_script git:(main) ✗ sudo venv/bin/python3 main.py uninstall nodataperm
ok
INFO: Uninstallation finished
➜  waydroid_script git:(main) ✗ 
```